### PR TITLE
fixed lora_rx_info type to int16_t

### DIFF
--- a/embit.h
+++ b/embit.h
@@ -15,7 +15,7 @@ typedef struct {
     embit_header_t header;
     char *payload;
     size_t payload_len;
-    uint8_t rssi;
+    int16_t rssi;
     int8_t snr;
 } embit_packet_t;
 

--- a/lora.h
+++ b/lora.h
@@ -3,7 +3,7 @@
 
 #include "net/netdev.h"
 
-typedef void (lora_data_cb_t)(const char *buffer, size_t len, uint8_t *rssi, int8_t *snr);
+typedef void (lora_data_cb_t)(const char *buffer, size_t len, int16_t *rssi, int8_t *snr);
 
 typedef struct {
     uint8_t bandwidth;

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ static lora_state_t lora;
 static struct {
     uint16_t sleep_seconds;
     uint16_t message_counter;
-    uint8_t last_rssi;
+    int16_t last_rssi;
     int8_t last_snr;
     uint8_t tx_power;
 } persist;

--- a/protocol.c
+++ b/protocol.c
@@ -39,7 +39,7 @@ void protocol_init(consume_data_cb_t *packet_consumer)
 #endif
 }
 
-void protocol_in(const char *buffer, size_t len, uint8_t *rssi, int8_t *snr)
+void protocol_in(const char *buffer, size_t len, int16_t *rssi, int8_t *snr)
 {
     embit_header_t *header;
     char *payload;

--- a/protocol.h
+++ b/protocol.h
@@ -4,7 +4,7 @@
 #include "net/netdev.h"
 
 void protocol_init(consume_data_cb_t *packet_consumer);
-void protocol_in(const char *buffer, size_t len, uint8_t *rssi, int8_t *snr);
+void protocol_in(const char *buffer, size_t len, int16_t *rssi, int8_t *snr);
 void protocol_out(const embit_header_t *header, const char *buffer, const size_t len);
 
 #endif /* PROTOCOL_H */


### PR DESCRIPTION
Fixed rssi type for the new Version of RIOT.